### PR TITLE
Fix clean error for Makefile1

### DIFF
--- a/Concurrency/Labs/Lab 1:The Toolchain/helloThreads/Makefile1
+++ b/Concurrency/Labs/Lab 1:The Toolchain/helloThreads/Makefile1
@@ -13,4 +13,4 @@ SIMPLE: helloThreads.cpp
 
 
 CLEAN:
-	rm *.o
+	rm a.out


### PR DESCRIPTION
For the Makefile1, it will generate a.out as an output.
So rm *.o will not work in this case.
Fixed by changing it to rm a.out.